### PR TITLE
disabling text input field when submit button is pressed. #39

### DIFF
--- a/webapp/pages/04_2_-_Current_Practices.py
+++ b/webapp/pages/04_2_-_Current_Practices.py
@@ -70,6 +70,7 @@ assurance_meaning = question_generator.generate_streamlit_element(
     questions["assurance_meaning"]["question"],
     questions["assurance_meaning"]["type"],
     key=ASSURANCE_MEANING_STATE_KEY,
+    disabled=st.session_state.disabled,
 )
 
 # Submit button for assurance definition

--- a/webapp/pages/08_Frameworks_Results.py
+++ b/webapp/pages/08_Frameworks_Results.py
@@ -161,7 +161,7 @@ try:
 
 except ValueError as e:
     # Exception message is human-readable
-    st.warning(e) #TODO remove this before launch
+    st.warning(e)  # TODO remove this before launch
     st.warning(
         "This page will show personalized insights"
         " on perceptions of the Gemini Principles amongst your peers."

--- a/webapp/streamlit_utils.py
+++ b/webapp/streamlit_utils.py
@@ -186,6 +186,7 @@ class QuestionGenerator:
         self,
         question_text: str,
         question_type: str,
+        disabled: bool = False,
         options: Optional[list] = None,
         key: Optional[str] = None,
         help: Optional[str] = None,
@@ -295,6 +296,7 @@ class QuestionGenerator:
                 question_text,
                 key=widget_key,
                 on_change=store_in_session,
+                disabled=disabled,
                 args=(key,),
             )
         elif question_type == "radio" and options is not None:


### PR DESCRIPTION
When participants have added their definition of Assurance and press submit I want to disable the field. The submit button triggers a definition given by us and I don't want them to go back and adjust their response. During the cognitive pilot participants have mentioned reading the definition made them want to change their response.